### PR TITLE
python>=3.5,<3.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,5 @@ dependencies:
 - conda>=4.6  # <-- reflect this requirement in the README
 - conda-pack
 - jq==1.6
-- python>=3.5
+- python>=3.5,<3.8
+


### PR DESCRIPTION
We have an issue where we lock `poetry` to version `0.12.17` which doesn't support `python 3.8`.

Proposal to pin the `python` version to below `3.8` until we upgrade poetry.

Related issue:
https://github.com/python-poetry/poetry/issues/1377#issuecomment-543369545