### PR TITLE
Use correct settings variables per version of Poetry

### DIFF
--- a/src/cpip-pack
+++ b/src/cpip-pack
@@ -91,14 +91,14 @@ install_compilers()
             local add="$(echo "$link" | jq '[.[].name]')"
         [[ $unlink ]] && [[ $unlink != "null" ]] &&
             local sub="$(echo "$unlink" | jq '[.[].name]')"
-        
+
         # filter out only packages that were added, NOT updated/downgraded
         all_compiler_pkgs="$add"
         [[ $add ]] &&
             tmp_pkgs="$add"
         [[ $add ]] && [[ $sub ]] &&
             tmp_pkgs="$(jq_diff "$add" "$sub")"
-        
+
         # library packages stay, the rest are temporary
         [[ $tmp_pkgs ]] &&
             tmp_pkgs="$(echo "$tmp_pkgs" | jq -r '.[]' | grep -v "^lib")"
@@ -171,16 +171,31 @@ install_pip()
     fi
 }
 
+get_poetry_major_version()
+{
+    poetry_major_version=$(poetry --version | awk '{print $3}' | cut -f1 -d '.')
+    poetry_major_version=${poetry_major_version:-0}
+}
+
 set_poetry_config()
 {
-    venvs_create="$(poetry config settings.virtualenvs.create)"  # <-- save previous value
-    poetry config settings.virtualenvs.create "false"
+    if [[ $poetry_major_version -eq 0 ]]; then
+        venvs_create="$(poetry config settings.virtualenvs.create)"  # <-- save previous value
+        poetry config settings.virtualenvs.create "false"
+    else
+        venvs_create="$(poetry config virtualenvs.create)"  # <-- save previous value
+        poetry config virtualenvs.create "false"
+    fi
 }
 
 restore_poetry_config()
 {
     if [[ $venvs_create ]]; then
-        poetry config settings.virtualenvs.create "$venvs_create"
+        if [[ $poetry_major_version -eq 0 ]]; then
+            poetry config settings.virtualenvs.create "$venvs_create"
+        else
+            poetry config virtualenvs.create "$venvs_create"
+        fi
         unset venvs_create
     fi
 }
@@ -265,7 +280,7 @@ usage()
 
 advanced_usage()
 {
-    
+
     # NOTE: if you update this print message, please update README.md
     usage
     echo     "$____"
@@ -277,7 +292,7 @@ advanced_usage()
         echo "$____" "Package all dependencies into a portable conda environment tarball"
     fi
     echo     "$____"
-    
+
     echo     "$____" "required arguments:"
     echo     "$____" "  --name, -n PROJECT        Name of the project. Will be used for the name in"
     echo     "$____" "                            the output $output."
@@ -448,7 +463,7 @@ fi
 
 # set other output variables
 output_dir="$(py_realpath "$output_dir")"  # <-- set to absolute path
-if [[ $create ]]; then 
+if [[ $create ]]; then
     output="$output_dir/$name"
 else
     output_name="$name"
@@ -537,7 +552,7 @@ create_and_activate
 # install compilers before updating environment <-- very important to follow this order
 conditional_install_compilers
 
-# update the environment 
+# update the environment
 for file in "${files[@]}"; do
     conda_env_update
 done
@@ -550,9 +565,12 @@ if [[ $poetry_dir ]]; then
     poetry_install="${bold}[${green}poetry-install${reset}${bold}]${reset}"
     echo "$info" "Poetry project specified in '$poetry_dir': running $poetry_install..."
 
+    # get the poetry major version
+    get_poetry_major_version
+
     # change logging for poetry_install
     set_logging "$default_tag $poetry_install"
-   
+
     poetry_dir="$(py_realpath "$poetry_dir")"  # <-- set to absolute path
     unset_pip_local_install
     set_poetry_config

--- a/src/cpip-pack
+++ b/src/cpip-pack
@@ -173,8 +173,8 @@ install_pip()
 
 get_poetry_major_version()
 {
-    poetry_major_version=$(poetry --version | awk '{print $3}' | cut -f1 -d '.')
-    poetry_major_version=${poetry_major_version:-0}
+    poetry_major_version="$(poetry --version | awk '{print $3}' | cut -f1 -d '.')"
+    poetry_major_version="${poetry_major_version:-0}"
 }
 
 set_poetry_config()


### PR DESCRIPTION
In Poetry 1, there is no longer a "settings" prefix for configuration variables.  See https://github.com/python-poetry/poetry/pull/1272 for more information.

This PR checks the version number of the installed version of Poetry, and uses the corresponding name for the relevant configuration variable.