### PR TITLE
Add swig compiler but remove after install

### DIFF
--- a/bin/cpip
+++ b/bin/cpip
@@ -99,11 +99,13 @@ if [[ $OSTYPE == "linux-gnu" ]]; then
     cc_pkg="gcc_linux-64"
     cxx_pkg="gxx_linux-64"
     gfortran_pkg="gfortran_linux-64"
+    swig_pkg="swig"
     linux=true
 elif [[ $OSTYPE == "darwin"* ]]; then
     cc_pkg="clang_osx-64"
     cxx_pkg="clangxx_osx-64"
     gfortran_pkg="gfortran_osx-64"
+    swig_pkg="swig"
     macos=true
 else
     >&2 echo "$error" "OS not supported!"

--- a/src/cpip-pack
+++ b/src/cpip-pack
@@ -73,7 +73,7 @@ install_compilers()
         fi
 
         # install compilers
-        local pkgs=("$cc_pkg" "$cxx_pkg" "$gfortran_pkg")
+        local pkgs=("$cc_pkg" "$cxx_pkg" "$gfortran_pkg" "$swig_pkg")
         local pkg_diff="$(conda install --override-channels -c anaconda ${pkgs[@]} --no-update-deps --json --quiet)"
         local install_error="$(echo "$pkg_diff" | jq -r '.error')"
         if [[ $install_error != "null" ]]; then


### PR DESCRIPTION
Adds swig compiler for both linux and mac.

I checked https://anaconda.org/search?q=swig and the package name is `swig` for anaconda on both linux and mac.

Added like the other compilers that should be getting installed then removed due to licensing issues.

More context can be found on: https://eigentech.atlassian.net/browse/ENG-6171