### PR TITLE
BUG | ENG-6286 Keep pcre as required library

### DIFF
--- a/src/cpip-pack
+++ b/src/cpip-pack
@@ -99,9 +99,9 @@ install_compilers()
         [[ $add ]] && [[ $sub ]] &&
             tmp_pkgs="$(jq_diff "$add" "$sub")"
 
-        # library packages stay, the rest are temporary
+        # library packages and pcre stay, the rest are temporary
         [[ $tmp_pkgs ]] &&
-            tmp_pkgs="$(echo "$tmp_pkgs" | jq -r '.[]' | grep -v "^lib")"
+            tmp_pkgs="$(echo "$tmp_pkgs" | jq -r '.[]' | grep -v "^lib\|^pcre")"
         [[ $build_tools ]] && unset tmp_pkgs
 
         set_compiler_env


### PR DESCRIPTION
https://eigentech.atlassian.net/browse/ENG-6386

We were having an issue when using nginx in cpip envirnoment due to a missing library (pcre) which is getting uninstalled from the environment when building the installer with cpip.