### PR TITLE
Improvements on linux compilers setup

### DIFF
--- a/bin/cpip
+++ b/bin/cpip
@@ -96,12 +96,12 @@ set_logging "$default_tag"
 
 # check os to find the right compilers
 if [[ $OSTYPE == "linux-gnu" ]]; then
-    cc_pkg="gcc_linux-64"
-    cxx_pkg="gxx_linux-64"
-    gfortran_pkg="gfortran_linux-64"
-    ld_impl="ld_impl_linux-64"
-    swig_pkg="swig"
-    pkg_config="pkg-config"
+    cc_pkg="gcc_linux-64==7.2.0"
+    cxx_pkg="gxx_linux-64==7.2.0"
+    gfortran_pkg="gfortran_linux-64==7.2.0"
+    ld_impl="ld_impl_linux-64==2.33.1"
+    swig_pkg="swig==4.0.1"
+    pkg_config="pkg-config==0.29.2"
     linux=true
 elif [[ $OSTYPE == "darwin"* ]]; then
     cc_pkg="clang_osx-64"

--- a/bin/cpip
+++ b/bin/cpip
@@ -100,7 +100,7 @@ if [[ $OSTYPE == "linux-gnu" ]]; then
     cxx_pkg="gxx_linux-64==7.2.0"
     gfortran_pkg="gfortran_linux-64==7.2.0"
     ld_impl="ld_impl_linux-64==2.33.1"
-    swig_pkg="swig==4.0.1"
+    swig_pkg="swig==4.0.2"
     pkg_config="pkg-config==0.29.2"
     linux=true
 elif [[ $OSTYPE == "darwin"* ]]; then

--- a/src/cpip-pack
+++ b/src/cpip-pack
@@ -74,7 +74,7 @@ install_compilers()
 
         # install compilers
         local pkgs=("$cc_pkg" "$cxx_pkg" "$gfortran_pkg" "$swig_pkg" "$ld_impl" "$pkg_config")
-        local pkg_diff="$(conda install --override-channels -c anaconda ${pkgs[@]} --no-update-deps --json --quiet)"
+        local pkg_diff="$(conda install --override-channels -c anaconda -c conda-forge ${pkgs[@]} --no-update-deps --json --quiet)"
         local install_error="$(echo "$pkg_diff" | jq -r '.error')"
         if [[ $install_error != "null" ]]; then
             >&2 echo -e "$error" "$install_error"
@@ -101,7 +101,7 @@ install_compilers()
 
         # library packages and pcre stay, the rest are temporary
         [[ $tmp_pkgs ]] &&
-            tmp_pkgs="$(echo "$tmp_pkgs" | jq -r '.[]' | grep -v "^lib\|^pcre")"
+            tmp_pkgs="$(echo "$tmp_pkgs" | jq -r '.[]' | grep -v "^_\|^lib\|^pcre")"
         [[ $build_tools ]] && unset tmp_pkgs
 
         set_compiler_env

--- a/src/cpip-pack
+++ b/src/cpip-pack
@@ -74,7 +74,7 @@ install_compilers()
 
         # install compilers
         local pkgs=("$cc_pkg" "$cxx_pkg" "$gfortran_pkg" "$swig_pkg" "$ld_impl" "$pkg_config")
-        local pkg_diff="$(conda install --override-channels -c anaconda -c conda-forge ${pkgs[@]} --no-update-deps --json --quiet)"
+        local pkg_diff="$(conda install --override-channels -c anaconda ${pkgs[@]} --no-update-deps --json --quiet)"
         local install_error="$(echo "$pkg_diff" | jq -r '.error')"
         if [[ $install_error != "null" ]]; then
             >&2 echo -e "$error" "$install_error"


### PR DESCRIPTION
We now have all linux compilers pinned to a version due to issues with conda channels,
added conda-forge as a channel in addition to anaconda channel
made sure that packages starting with '_' are kept when we are doing compiler cleanup


Fixes #15 